### PR TITLE
Add filter over referenced collection

### DIFF
--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -9,12 +9,15 @@ from ...page import models
 from ..attribute.shared_filters import (
     CONTAINS_TYPING,
     AssignedAttributeWhereInput,
+    clean_up_referenced_global_ids,
     get_attribute_values_by_boolean_value,
     get_attribute_values_by_date_time_value,
     get_attribute_values_by_date_value,
     get_attribute_values_by_numeric_value,
     get_attribute_values_by_referenced_category_ids,
     get_attribute_values_by_referenced_category_slugs,
+    get_attribute_values_by_referenced_collection_ids,
+    get_attribute_values_by_referenced_collection_slugs,
     get_attribute_values_by_referenced_page_ids,
     get_attribute_values_by_referenced_page_slugs,
     get_attribute_values_by_referenced_product_ids,
@@ -308,6 +311,48 @@ def filter_by_contains_referenced_category_slugs(
     return Q()
 
 
+def filter_by_contains_referenced_collection_slugs(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+):
+    """Build an expression to filter pages based on their references to collections.
+
+    - If `contains_all` is provided, only pages that reference all of the
+    specified collections will match.
+    - If `contains_any` is provided, pages that reference at least one of
+    the specified collections will match.
+    """
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    if contains_all:
+        expression = Q()
+        for collection_slug in contains_all:
+            referenced_attr_values = (
+                get_attribute_values_by_referenced_collection_slugs(
+                    slugs=[collection_slug], db_connection_name=db_connection_name
+                )
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+        return expression
+
+    if contains_any:
+        referenced_attr_values = get_attribute_values_by_referenced_collection_slugs(
+            slugs=contains_any, db_connection_name=db_connection_name
+        )
+        return _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
+    return Q()
+
+
 def filter_by_contains_referenced_variant_skus(
     attr_id: int | None,
     attr_value: CONTAINS_TYPING,
@@ -353,6 +398,7 @@ def _filter_by_contains_all_referenced_object_ids(
     product_ids: set[int],
     page_ids: set[int],
     category_ids: set[int],
+    collection_ids: set[int],
     attr_id: int | None,
     db_connection_name: str,
 ) -> Q:
@@ -397,7 +443,16 @@ def _filter_by_contains_all_referenced_object_ids(
                 db_connection_name=db_connection_name,
                 referenced_attr_values=referenced_attr_values,
             )
-
+    if collection_ids:
+        for collection_id in collection_ids:
+            referenced_attr_values = get_attribute_values_by_referenced_collection_ids(
+                ids=[collection_id], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
     return expression
 
 
@@ -406,6 +461,7 @@ def _filter_by_contains_any_referenced_object_ids(
     product_ids: set[int],
     page_ids: set[int],
     category_ids: set[int],
+    collection_ids: set[int],
     attr_id: int | None,
     db_connection_name: str,
 ) -> Q:
@@ -446,6 +502,15 @@ def _filter_by_contains_any_referenced_object_ids(
             db_connection_name=db_connection_name,
             referenced_attr_values=referenced_attr_values,
         )
+    if collection_ids:
+        referenced_attr_values = get_attribute_values_by_referenced_collection_ids(
+            ids=list(collection_ids), db_connection_name=db_connection_name
+        )
+        expression |= _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
     return expression
 
 
@@ -457,21 +522,12 @@ def filter_by_contains_referenced_object_ids(
     contains_all = attr_value.get("contains_all")
     contains_any = attr_value.get("contains_any")
 
-    variant_ids = set()
-    product_ids = set()
-    page_ids = set()
-    category_ids = set()
-
-    for obj_id in contains_any or contains_all or []:
-        type_, id_ = graphene.Node.from_global_id(obj_id)
-        if type_ == "Page":
-            page_ids.add(id_)
-        elif type_ == "Product":
-            product_ids.add(id_)
-        elif type_ == "ProductVariant":
-            variant_ids.add(id_)
-        elif type_ == "Category":
-            category_ids.add(id_)
+    grouped_ids = clean_up_referenced_global_ids(contains_any or contains_all or [])
+    variant_ids = grouped_ids["ProductVariant"]
+    product_ids = grouped_ids["Product"]
+    page_ids = grouped_ids["Page"]
+    category_ids = grouped_ids["Category"]
+    collection_ids = grouped_ids["Collection"]
 
     if contains_all:
         return _filter_by_contains_all_referenced_object_ids(
@@ -479,6 +535,7 @@ def filter_by_contains_referenced_object_ids(
             product_ids=product_ids,
             page_ids=page_ids,
             category_ids=category_ids,
+            collection_ids=collection_ids,
             attr_id=attr_id,
             db_connection_name=db_connection_name,
         )
@@ -488,6 +545,7 @@ def filter_by_contains_referenced_object_ids(
             product_ids=product_ids,
             page_ids=page_ids,
             category_ids=category_ids,
+            collection_ids=collection_ids,
             attr_id=attr_id,
             db_connection_name=db_connection_name,
         )
@@ -539,6 +597,12 @@ def filter_objects_by_reference_attributes(
         filter_expression &= filter_by_contains_referenced_category_slugs(
             attr_id,
             attr_value["category_slugs"],
+            db_connection_name,
+        )
+    if "collection_slugs" in attr_value:
+        filter_expression &= filter_by_contains_referenced_collection_slugs(
+            attr_id,
+            attr_value["collection_slugs"],
             db_connection_name,
         )
     return filter_expression

--- a/saleor/graphql/page/tests/queries/pages_with_where/test_with_where_references_collections.py
+++ b/saleor/graphql/page/tests/queries/pages_with_where/test_with_where_references_collections.py
@@ -1,0 +1,308 @@
+import graphene
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import QUERY_PAGES_WITH_WHERE
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 2), ("containsAll", 1)],
+)
+def test_pages_query_with_attr_slug_and_attribute_value_reference_to_collections(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    product_type_collection_reference_attribute,
+    collection_list,
+):
+    # given
+    page_type.page_attributes.add(product_type_collection_reference_attribute)
+
+    first_collection = collection_list[0]
+    second_collection = collection_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_collection_reference_attribute,
+                name=f"Collection {first_collection.pk}",
+                slug=f"collection-{first_collection.pk}",
+                reference_collection=first_collection,
+            ),
+            AttributeValue(
+                attribute=product_type_collection_reference_attribute,
+                name=f"Collection {second_collection.pk}",
+                slug=f"collection-{second_collection.pk}",
+                reference_collection=second_collection,
+            ),
+        ]
+    )
+
+    page_with_both_references = page_list[0]
+    associate_attribute_values_to_instance(
+        page_with_both_references,
+        {
+            product_type_collection_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    page_with_single_reference = page_list[1]
+    associate_attribute_values_to_instance(
+        page_with_single_reference,
+        {product_type_collection_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "collection-reference",
+                    "value": {
+                        "reference": {
+                            "collectionSlugs": {
+                                filter_type: [
+                                    first_collection.slug,
+                                    second_collection.slug,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+    assert pages_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Page", page_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 2), ("containsAll", 1)],
+)
+def test_pages_query_with_attribute_value_reference_to_collection(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    product_type_collection_reference_attribute,
+    collection_list,
+):
+    # given
+    second_collection_reference_attribute = Attribute.objects.create(
+        slug="second-collection-reference",
+        name="collection reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.COLLECTION,
+    )
+
+    page_type.page_attributes.add(product_type_collection_reference_attribute)
+    page_type.page_attributes.add(second_collection_reference_attribute)
+
+    first_collection = collection_list[0]
+    second_collection = collection_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_collection_reference_attribute,
+                name=f"Collection {first_collection.pk}",
+                slug=f"collection-{first_collection.pk}",
+                reference_collection=first_collection,
+            ),
+            AttributeValue(
+                attribute=second_collection_reference_attribute,
+                name=f"Collection {second_collection.pk}",
+                slug=f"collection-{second_collection.pk}",
+                reference_collection=second_collection,
+            ),
+        ]
+    )
+
+    page_with_both_references = page_list[0]
+    associate_attribute_values_to_instance(
+        page_with_both_references,
+        {
+            product_type_collection_reference_attribute.pk: [
+                attribute_value_1,
+            ],
+            second_collection_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    page_with_single_reference = page_list[1]
+    associate_attribute_values_to_instance(
+        page_with_single_reference,
+        {second_collection_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "collectionSlugs": {
+                                filter_type: [
+                                    first_collection.slug,
+                                    second_collection.slug,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+    assert pages_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Page", page_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_pages_query_with_attr_slug_and_attribute_value_referenced_collection_ids(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    product_type_collection_reference_attribute,
+    collection_list,
+):
+    # given
+    page_type.page_attributes.add(
+        product_type_collection_reference_attribute,
+    )
+    first_collection = collection_list[0]
+    second_collection = collection_list[1]
+    third_collection = collection_list[2]
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_collection_reference_attribute,
+                    name=f"collection {first_collection.pk}",
+                    slug=f"collection-{first_collection.pk}",
+                    reference_collection=first_collection,
+                ),
+                AttributeValue(
+                    attribute=product_type_collection_reference_attribute,
+                    name=f"collection {second_collection.pk}",
+                    slug=f"collection-{second_collection.pk}",
+                    reference_collection=second_collection,
+                ),
+                AttributeValue(
+                    attribute=product_type_collection_reference_attribute,
+                    name=f"collection {third_collection.pk}",
+                    slug=f"collection-{third_collection.pk}",
+                    reference_collection=third_collection,
+                ),
+            ]
+        )
+    )
+    fist_page_with_all_ids = page_list[0]
+    second_page_with_all_ids = page_list[1]
+    page_with_single_id = page_list[2]
+    associate_attribute_values_to_instance(
+        fist_page_with_all_ids,
+        {
+            product_type_collection_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_page_with_all_ids,
+        {
+            product_type_collection_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        page_with_single_id,
+        {
+            product_type_collection_reference_attribute.pk: [
+                first_attr_value,
+            ],
+        },
+    )
+    referenced_first_global_id = to_global_id_or_none(first_collection)
+    referenced_second_global_id = to_global_id_or_none(second_collection)
+    referenced_third_global_id = to_global_id_or_none(third_collection)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_collection_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                },
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(page_list) > len(pages_nodes)
+    assert len(pages_nodes) == expected_count

--- a/saleor/graphql/product/filters/product_attributes.py
+++ b/saleor/graphql/product/filters/product_attributes.py
@@ -3,7 +3,6 @@ import math
 from collections import defaultdict
 from typing import Literal, TypedDict
 
-import graphene
 from django.db.models import Exists, OuterRef, Q, QuerySet
 from graphql import GraphQLError
 
@@ -18,12 +17,15 @@ from ....attribute.models import (
 from ....product.models import Product, ProductVariant
 from ...attribute.shared_filters import (
     CONTAINS_TYPING,
+    clean_up_referenced_global_ids,
     get_attribute_values_by_boolean_value,
     get_attribute_values_by_date_time_value,
     get_attribute_values_by_date_value,
     get_attribute_values_by_numeric_value,
     get_attribute_values_by_referenced_category_ids,
     get_attribute_values_by_referenced_category_slugs,
+    get_attribute_values_by_referenced_collection_ids,
+    get_attribute_values_by_referenced_collection_slugs,
     get_attribute_values_by_referenced_page_ids,
     get_attribute_values_by_referenced_page_slugs,
     get_attribute_values_by_referenced_product_ids,
@@ -589,11 +591,54 @@ def filter_by_contains_referenced_category_slugs(
     return Q()
 
 
+def filter_by_contains_referenced_collection_slugs(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+):
+    """Build an expression to filter products based on their references to collections.
+
+    - If `contains_all` is provided, only products that reference all of the
+    specified collections will match.
+    - If `contains_any` is provided, products that reference at least one of
+    the specified collections will match.
+    """
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    if contains_all:
+        expression = Q()
+        for collection_slug in contains_all:
+            referenced_attr_values = (
+                get_attribute_values_by_referenced_collection_slugs(
+                    slugs=[collection_slug], db_connection_name=db_connection_name
+                )
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+        return expression
+
+    if contains_any:
+        referenced_attr_values = get_attribute_values_by_referenced_collection_slugs(
+            slugs=contains_any, db_connection_name=db_connection_name
+        )
+        return _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
+    return Q()
+
+
 def _filter_by_contains_all_referenced_object_ids(
     variant_ids: set[int],
     product_ids: set[int],
     page_ids: set[int],
     category_ids: set[int],
+    collection_ids: set[int],
     attr_id: int | None,
     db_connection_name: str,
 ) -> Q:
@@ -638,6 +683,16 @@ def _filter_by_contains_all_referenced_object_ids(
                 db_connection_name=db_connection_name,
                 referenced_attr_values=referenced_attr_values,
             )
+    if collection_ids:
+        for collection_id in collection_ids:
+            referenced_attr_values = get_attribute_values_by_referenced_collection_ids(
+                ids=[collection_id], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
     return expression
 
 
@@ -646,6 +701,7 @@ def _filter_by_contains_any_referenced_object_ids(
     product_ids: set[int],
     page_ids: set[int],
     category_ids: set[int],
+    collection_ids: set[int],
     attr_id: int | None,
     db_connection_name: str,
 ) -> Q:
@@ -686,6 +742,15 @@ def _filter_by_contains_any_referenced_object_ids(
             db_connection_name=db_connection_name,
             referenced_attr_values=referenced_attr_values,
         )
+    if collection_ids:
+        referenced_attr_values = get_attribute_values_by_referenced_collection_ids(
+            ids=list(collection_ids), db_connection_name=db_connection_name
+        )
+        expression |= _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
     return expression
 
 
@@ -697,21 +762,12 @@ def filter_by_contains_referenced_object_ids(
     contains_all = attr_value.get("contains_all")
     contains_any = attr_value.get("contains_any")
 
-    variant_ids = set()
-    product_ids = set()
-    page_ids = set()
-    category_ids = set()
-
-    for obj_id in contains_any or contains_all or []:
-        type_, id_ = graphene.Node.from_global_id(obj_id)
-        if type_ == "Page":
-            page_ids.add(id_)
-        elif type_ == "Product":
-            product_ids.add(id_)
-        elif type_ == "ProductVariant":
-            variant_ids.add(id_)
-        elif type_ == "Category":
-            category_ids.add(id_)
+    grouped_ids = clean_up_referenced_global_ids(contains_any or contains_all or [])
+    variant_ids = grouped_ids["ProductVariant"]
+    product_ids = grouped_ids["Product"]
+    page_ids = grouped_ids["Page"]
+    category_ids = grouped_ids["Category"]
+    collection_ids = grouped_ids["Collection"]
 
     if contains_all:
         return _filter_by_contains_all_referenced_object_ids(
@@ -719,6 +775,7 @@ def filter_by_contains_referenced_object_ids(
             product_ids=product_ids,
             page_ids=page_ids,
             category_ids=category_ids,
+            collection_ids=collection_ids,
             attr_id=attr_id,
             db_connection_name=db_connection_name,
         )
@@ -728,6 +785,7 @@ def filter_by_contains_referenced_object_ids(
             product_ids=product_ids,
             page_ids=page_ids,
             category_ids=category_ids,
+            collection_ids=collection_ids,
             attr_id=attr_id,
             db_connection_name=db_connection_name,
         )
@@ -743,6 +801,7 @@ def filter_objects_by_reference_attributes(
             "product_slugs",
             "product_variant_skus",
             "category_slugs",
+            "collection_slugs",
         ],
         CONTAINS_TYPING,
     ],
@@ -778,6 +837,12 @@ def filter_objects_by_reference_attributes(
         filter_expression &= filter_by_contains_referenced_category_slugs(
             attr_id,
             attr_value["category_slugs"],
+            db_connection_name,
+        )
+    if "collection_slugs" in attr_value:
+        filter_expression &= filter_by_contains_referenced_collection_slugs(
+            attr_id,
+            attr_value["collection_slugs"],
             db_connection_name,
         )
     return filter_expression

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_collections.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_collections.py
@@ -1,0 +1,303 @@
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_products_query_with_attr_slug_and_attribute_value_reference_to_collections(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_type,
+    product_list,
+    collection_list,
+    product_type_collection_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(product_type_collection_reference_attribute)
+
+    first_collection = collection_list[0]
+    second_collection = collection_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_collection_reference_attribute,
+                name=f"Category {first_collection.pk}",
+                slug=f"collection-{first_collection.pk}",
+                reference_collection=first_collection,
+            ),
+            AttributeValue(
+                attribute=product_type_collection_reference_attribute,
+                name=f"Category {second_collection.pk}",
+                slug=f"collection-{second_collection.pk}",
+                reference_collection=second_collection,
+            ),
+        ]
+    )
+    product_with_both_references = product_list[0]
+    associate_attribute_values_to_instance(
+        product_with_both_references,
+        {
+            product_type_collection_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    product_with_single_reference = product_list[1]
+    associate_attribute_values_to_instance(
+        product_with_single_reference,
+        {product_type_collection_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "collection-reference",
+                    "value": {
+                        "reference": {
+                            "collectionSlugs": {
+                                filter_type: [
+                                    first_collection.slug,
+                                    second_collection.slug,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_products_query_with_attribute_value_reference_to_collections(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    collection_list,
+    product_type_collection_reference_attribute,
+    channel_USD,
+):
+    # given
+    second_collection_reference_attribute = Attribute.objects.create(
+        slug="second-collection-reference",
+        name="Category reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.COLLECTION,
+    )
+    product_type.product_attributes.add(
+        product_type_collection_reference_attribute,
+        second_collection_reference_attribute,
+    )
+    first_collection = collection_list[0]
+    second_collection = collection_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_collection_reference_attribute,
+                name=f"Category {first_collection.pk}",
+                slug=f"collection-{first_collection.pk}",
+                reference_collection=first_collection,
+            ),
+            AttributeValue(
+                attribute=second_collection_reference_attribute,
+                name=f"Category {second_collection.pk}",
+                slug=f"collection-{second_collection.pk}",
+                reference_collection=second_collection,
+            ),
+        ]
+    )
+    product_with_both_references = product_list[0]
+    associate_attribute_values_to_instance(
+        product_with_both_references,
+        {
+            product_type_collection_reference_attribute.pk: [attribute_value_1],
+            second_collection_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    product_with_single_reference = product_list[1]
+    associate_attribute_values_to_instance(
+        product_with_single_reference,
+        {second_collection_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "collectionSlugs": {
+                                filter_type: [
+                                    first_collection.slug,
+                                    second_collection.slug,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_products_query_with_attr_slug_and_attribute_value_referenced_collection_ids(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    collection_list,
+    product_type_collection_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(product_type_collection_reference_attribute)
+
+    first_collection = collection_list[0]
+    second_collection = collection_list[1]
+    third_collection = collection_list[2]
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_collection_reference_attribute,
+                    name=f"Category {first_collection.pk}",
+                    slug=f"collection-{first_collection.pk}",
+                    reference_collection=first_collection,
+                ),
+                AttributeValue(
+                    attribute=product_type_collection_reference_attribute,
+                    name=f"Category {second_collection.pk}",
+                    slug=f"collection-{second_collection.pk}",
+                    reference_collection=second_collection,
+                ),
+                AttributeValue(
+                    attribute=product_type_collection_reference_attribute,
+                    name=f"Category {third_collection.pk}",
+                    slug=f"collection-{third_collection.pk}",
+                    reference_collection=third_collection,
+                ),
+            ]
+        )
+    )
+
+    first_product_with_all_ids = product_list[0]
+    second_product_with_all_ids = product_list[1]
+    product_with_single_id = product_list[2]
+    associate_attribute_values_to_instance(
+        first_product_with_all_ids,
+        {
+            product_type_collection_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_product_with_all_ids,
+        {
+            product_type_collection_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_with_single_id,
+        {product_type_collection_reference_attribute.pk: [first_attr_value]},
+    )
+
+    referenced_first_global_id = to_global_id_or_none(first_collection)
+    referenced_second_global_id = to_global_id_or_none(second_collection)
+    referenced_third_global_id = to_global_id_or_none(third_collection)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_collection_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_references_collections.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_references_collections.py
@@ -1,0 +1,299 @@
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_product_variants_query_with_attr_slug_and_attribute_value_reference_to_collections(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type_collection_reference_attribute,
+    channel_USD,
+    collection_list,
+):
+    # given
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(product_type_collection_reference_attribute)
+
+    first_collection = collection_list[0]
+    second_collection = collection_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_collection_reference_attribute,
+                name=f"Category {first_collection.pk}",
+                slug=f"collection-{first_collection.pk}",
+                reference_collection=first_collection,
+            ),
+            AttributeValue(
+                attribute=product_type_collection_reference_attribute,
+                name=f"Category {second_collection.pk}",
+                slug=f"collection-{second_collection.pk}",
+                reference_collection=second_collection,
+            ),
+        ]
+    )
+    product_variant_with_both_references = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        product_variant_with_both_references,
+        {
+            product_type_collection_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    product_variant_with_single_reference = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        product_variant_with_single_reference,
+        {product_type_collection_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "collection-reference",
+                    "value": {
+                        "reference": {
+                            "collectionSlugs": {
+                                filter_type: [
+                                    first_collection.slug,
+                                    second_collection.slug,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_product_variants_query_with_attribute_value_reference_to_collections(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type,
+    product_type_collection_reference_attribute,
+    channel_USD,
+    collection_list,
+):
+    # given
+    second_collection_reference_attribute = Attribute.objects.create(
+        slug="second-collection-reference",
+        name="Category reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.COLLECTION,
+    )
+    product_type.variant_attributes.add(
+        product_type_collection_reference_attribute,
+        second_collection_reference_attribute,
+    )
+
+    first_collection = collection_list[0]
+    second_collection = collection_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_collection_reference_attribute,
+                name=f"Category {first_collection.pk}",
+                slug=f"collection-{first_collection.pk}",
+                reference_collection=first_collection,
+            ),
+            AttributeValue(
+                attribute=second_collection_reference_attribute,
+                name=f"Category {second_collection.pk}",
+                slug=f"collection-{second_collection.pk}",
+                reference_collection=second_collection,
+            ),
+        ]
+    )
+
+    product_variant_with_both_references = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        product_variant_with_both_references,
+        {
+            product_type_collection_reference_attribute.pk: [attribute_value_1],
+            second_collection_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    product_variant_with_single_reference = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        product_variant_with_single_reference,
+        {second_collection_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "collectionSlugs": {
+                                filter_type: [
+                                    first_collection.slug,
+                                    second_collection.slug,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 3), ("containsAll", 2)],
+)
+def test_product_variants_query_with_attr_slug_and_attribute_value_referenced_collection_ids(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type,
+    product_type_collection_reference_attribute,
+    channel_USD,
+    collection_list,
+):
+    # given
+    product_type.variant_attributes.add(product_type_collection_reference_attribute)
+
+    first_collection = collection_list[0]
+    second_collection = collection_list[1]
+    third_collection = collection_list[2]
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_collection_reference_attribute,
+                    name=f"Category {first_collection.pk}",
+                    slug=f"collection-{first_collection.pk}",
+                    reference_collection=first_collection,
+                ),
+                AttributeValue(
+                    attribute=product_type_collection_reference_attribute,
+                    name=f"Category {second_collection.pk}",
+                    slug=f"collection-{second_collection.pk}",
+                    reference_collection=second_collection,
+                ),
+                AttributeValue(
+                    attribute=product_type_collection_reference_attribute,
+                    name=f"Category {third_collection.pk}",
+                    slug=f"collection-{third_collection.pk}",
+                    reference_collection=third_collection,
+                ),
+            ]
+        )
+    )
+    first_product_variant_with_all_ids = product_variant_list[0]
+    second_product_variant_with_all_ids = product_variant_list[1]
+    product_variant_with_single_id = product_variant_list[3]
+    associate_attribute_values_to_instance(
+        first_product_variant_with_all_ids,
+        {
+            product_type_collection_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_product_variant_with_all_ids,
+        {
+            product_type_collection_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_variant_with_single_id,
+        {product_type_collection_reference_attribute.pk: [first_attr_value]},
+    )
+
+    referenced_first_global_id = to_global_id_or_none(first_collection)
+    referenced_second_global_id = to_global_id_or_none(second_collection)
+    referenced_third_global_id = to_global_id_or_none(third_collection)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_collection_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7192,6 +7192,11 @@ input AssignedAttributeReferenceInput {
   Returns objects with a reference pointing to a category identified by the given slug.
   """
   categorySlugs: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a collection identified by the given slug.
+  """
+  collectionSlugs: ContainsFilterInput
 }
 
 """


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/18233

I want to merge this change because it extends the filter to allow filtering objects by their referenced collection.

I’m skipping the changelog since the entire filter will be introduced in 3.22.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Doc...